### PR TITLE
Added condition to load the proper wifi driver for a nano 33 iot 

### DIFF
--- a/mkr10x0_iotc/mkr10x0_iotc.ino
+++ b/mkr10x0_iotc/mkr10x0_iotc.ino
@@ -21,6 +21,11 @@
 #define DEVICE_NAME "Arduino MKR1010"
 #endif
 
+#ifdef ARDUINO_SAMD_NANO_33_IOT
+  #include <WiFiNINA.h>
+  #define DEVICE_NAME "Arduino Nano 33 IOT"
+#endif
+
 #include <WiFiUdp.h>
 #include <RTCZero.h>
 #include <SimpleDHT.h>

--- a/mkr10x0_iotc/utils.h
+++ b/mkr10x0_iotc/utils.h
@@ -1,48 +1,11 @@
-// convert a float to a string as Arduino lacks an ftoa function
-char *dtostrf(double value, int width, unsigned int precision, char *result)
-{
-    int decpt, sign, reqd, pad;
-    const char *s, *e;
-    char *p;
-    s = fcvt(value, precision, &decpt, &sign);
-    if (precision == 0 && decpt == 0) {
-        s = (*s < '5') ? "0" : "1";
-        reqd = 1;
-    } else {
-        reqd = strlen(s);
-        if (reqd > decpt) reqd++;
-        if (decpt == 0) reqd++;
-    }
-    if (sign) reqd++;
-    p = result;
-    e = p + reqd;
-    pad = width - reqd;
-    if (pad > 0) {
-        e += pad;
-        while (pad-- > 0) *p++ = ' ';
-    }
-    if (sign) *p++ = '-';
-    if (decpt <= 0 && precision > 0) {
-        *p++ = '0';
-        *p++ = '.';
-        e++;
-        while ( decpt < 0 ) {
-            decpt++;
-            *p++ = '0';
-        }
-    }    
-    while (p < e) {
-        *p++ = *s++;
-        if (p == e) break;
-        if (--decpt == 0) *p++ = '.';
-    }
-    if (width < 0) {
-        pad = (reqd + width) * -1;
-        while (pad-- > 0) *p++ = ' ';
-    }
-    *p = 0;
-    return result;
+// From https://github.com/arduino/Arduino/blob/a2e7413d229812ff123cb8864747558b270498f1/hardware/arduino/sam/cores/arduino/avr/dtostrf.c
+char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
+    char fmt[20];
+    sprintf(fmt, "%%%d.%df", width, prec);
+    sprintf(sout, fmt, val);
+    return sout;
 }
+
 
 // implementation of printf for use in Arduino sketch
 void Serial_printf(char* fmt, ...) {


### PR DESCRIPTION
When trying to get this to work on an Arduino Nano 33 IOT I ran into issues picking the correct wifi driver and also found that the dtostrf method caused compile errors.

```terminal
In file included from /Users/cbitter/Documents/Arduino/mkr1000-iotc/mkr10x0_iotc/mkr10x0_iotc.ino:49:0:
sketch/./utils.h: In function 'char* dtostrf(double, int, unsigned int, char*)':
utils.h:7:9: error: 'fcvt' was not declared in this scope
     s = fcvt(value, precision, &decpt, &sign);
         ^~~~
sketch/./utils.h:7:9: note: suggested alternative: 'Oct'
     s = fcvt(value, precision, &decpt, &sign);
         ^~~~
         Oct
```

Swapping out the function fixed my issues.

